### PR TITLE
Root node id can now be detected

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -43,9 +43,9 @@ class Config
 
     /**
      * @see AbstractNestedSet::$rootNodeId
-     * @var int|string
+     * @var int|string|null
      */
-    public $rootNodeId = 1;
+    public $rootNodeId;
 
     /**
      * @see Find::$columns

--- a/src/Exception/InvalidRootNodeIdentifierException.php
+++ b/src/Exception/InvalidRootNodeIdentifierException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace metalinspired\NestedSet\Exception;
+
+use Throwable;
+
+class InvalidRootNodeIdentifierException extends InvalidArgumentException
+{
+    public function __construct($nodeId, $message = "", $code = 0, Throwable $previous = null)
+    {
+        $message = sprintf(
+            "Root node identifier must be an integer, string or NULL. Instance of %s given",
+            is_object($nodeId) ? get_class($nodeId) : gettype($nodeId)
+        );
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Exception/RootNodeNotDetectedException.php
+++ b/src/Exception/RootNodeNotDetectedException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace metalinspired\NestedSet\Exception;
+
+use Throwable;
+
+class RootNodeNotDetectedException extends RuntimeException
+{
+    public function __construct($message = "Could not detect root node", $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Find.php
+++ b/src/Find.php
@@ -187,7 +187,7 @@ class Find extends AbstractNestedSet
                 ["t.{$this->rightColumn}" => Expression::TYPE_IDENTIFIER],
                 ['q.rgt' => Expression::TYPE_IDENTIFIER],
                 ["t.{$this->idColumn}" => Expression::TYPE_IDENTIFIER],
-                $this->rootNodeId
+                $this->getRootNodeId()
             ]
         );
 
@@ -307,7 +307,7 @@ class Find extends AbstractNestedSet
                         ["parent.{$this->idColumn}" => Expression::TYPE_IDENTIFIER]
                     ]
                 ),
-                $this->rootNodeId
+                $this->getRootNodeId()
             );
 
         if ($this->includeSearchingNode) {
@@ -392,7 +392,7 @@ class Find extends AbstractNestedSet
                         ["t.{$this->idColumn}" => Expression::TYPE_IDENTIFIER]
                     ]
                 ),
-                $this->rootNodeId
+                $this->getRootNodeId()
             );
 
         $predicate = new Predicate();
@@ -623,7 +623,7 @@ class Find extends AbstractNestedSet
                         ["t.{$this->idColumn}" => Expression::TYPE_IDENTIFIER]
                     ]
                 ),
-                $this->rootNodeId
+                $this->getRootNodeId()
             );
 
         $predicate = new Predicate();

--- a/src/Manipulate.php
+++ b/src/Manipulate.php
@@ -117,7 +117,7 @@ class Manipulate extends AbstractNestedSet
         /*
          * Prevent user from moving nodes before or after root node
          */
-        if ($this->rootNodeId == $destination && ($position == self::MOVE_BEFORE || $position == self::MOVE_AFTER)) {
+        if ($this->getRootNodeId() == $destination && ($position == self::MOVE_BEFORE || $position == self::MOVE_AFTER)) {
             throw new Exception\RuntimeException('Node(s) can not be moved before or after root node');
         }
 
@@ -478,7 +478,7 @@ class Manipulate extends AbstractNestedSet
         /*
          * Prevent user from moving root node
          */
-        if ($this->rootNodeId == $source) {
+        if ($this->getRootNodeId() == $source) {
             throw new Exception\RuntimeException('Root node can\'t be moved');
         }
 
@@ -582,7 +582,7 @@ class Manipulate extends AbstractNestedSet
         /*
          * Prevent user from deleting root node
          */
-        if ($this->rootNodeId == $id) {
+        if ($this->getRootNodeId() == $id) {
             throw new Exception\RuntimeException('Root node can\'t be deleted');
         }
 

--- a/test/FindTest.php
+++ b/test/FindTest.php
@@ -19,6 +19,7 @@ class FindTest extends AbstractFindTest
 
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
+        $config->rootNodeId = 1;
 
         $this->nestedSet = new Find($config);
     }

--- a/test/FindWithColumnsSpecifiedTest.php
+++ b/test/FindWithColumnsSpecifiedTest.php
@@ -20,6 +20,7 @@ class FindWithColumnsSpecifiedTest extends AbstractFindTest
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
         $config->columns = self::$customColumns;
+        $config->rootNodeId = 1;
 
         $this->nestedSet = new Find($config);
     }

--- a/test/FindWithLimitTest.php
+++ b/test/FindWithLimitTest.php
@@ -20,6 +20,7 @@ class FindWithLimitTest extends AbstractFindTest
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
         $config->depthLimit = 2;
+        $config->rootNodeId = 1;
 
         $this->nestedSet = new Find($config);
     }

--- a/test/FindWithSearchingNodeIncludedTest.php
+++ b/test/FindWithSearchingNodeIncludedTest.php
@@ -21,6 +21,7 @@ class FindWithSearchingNodeIncludedTest extends AbstractFindTest
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
         $config->includeSearchingNode = true;
+        $config->rootNodeId = 1;
 
         $this->nestedSet = new Find($config);
     }

--- a/test/InsertTest.php
+++ b/test/InsertTest.php
@@ -26,6 +26,8 @@ class InsertTest extends AbstractTest
         
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
+        $config->rootNodeId = 1;
+
         $this->manipulate = new Manipulate($config);
     }
 

--- a/test/InvalidRootNodeTest.php
+++ b/test/InvalidRootNodeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace metalinspired\NestedSetTest;
+
+use metalinspired\NestedSet\Config;
+use metalinspired\NestedSet\Exception\RootNodeNotDetectedException;
+use metalinspired\NestedSet\Find;
+
+class InvalidRootNodeTest extends AbstractTest
+{
+    use GetQueryTableTrait;
+
+    /**
+     * @var Find
+     */
+    protected $find;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $config = Config::createWithPdo(self::$pdo);
+        $config->table = $GLOBALS[self::DB_TABLE];
+        $this->find = new Find($config);
+    }
+
+    public function getDataSet()
+    {
+        return $this->createXMLDataSet(__DIR__ . '/Fixture/InitialState.xml');
+    }
+
+    public function testEmptyTable()
+    {
+        $this->expectException(RootNodeNotDetectedException::class);
+
+        $this->find->findChildren(1);
+    }
+
+    public function testNoRootNode()
+    {
+        self::$pdo->exec("INSERT INTO `{$GLOBALS[self::DB_TABLE]}` (`lft`, `rgt`, `value`) VALUES (1, 2, 'node 1')");
+        self::$pdo->exec("INSERT INTO `{$GLOBALS[self::DB_TABLE]}` (`lft`, `rgt`, `value`) VALUES (3, 4, 'node 2')");
+
+        $this->expectException(RootNodeNotDetectedException::class);
+
+        $this->find->findChildren(1);
+    }
+}

--- a/test/ManipulateTest.php
+++ b/test/ManipulateTest.php
@@ -21,6 +21,8 @@ class ManipulateTest extends AbstractTest
 
         $config = Config::createWithPdo(self::$pdo);
         $config->table = $GLOBALS[self::DB_TABLE];
+        $config->rootNodeId = 1;
+
         $this->manipulate = new Manipulate($config);
     }
 


### PR DESCRIPTION
Root node id can now be detected if rootNodeId property is set to null, which is now default behavior